### PR TITLE
fix:fix database schema

### DIFF
--- a/prisma/migrations/20250120122051_update_datetime_fields/migration.sql
+++ b/prisma/migrations/20250120122051_update_datetime_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE `book` MODIFY `purchasedAt` DATETIME(3) NULL,
+    MODIFY `startedAt` DATETIME(3) NULL,
+    MODIFY `finishedAt` DATETIME(3) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,9 +19,9 @@ model Book {
   author      String     @default("") // 著者
   pagesRead   Int        @default(0) // 読了ページ数
   totalPages  Int        @default(0) // 総ページ数
-  purchasedAt DateTime?  @db.Date // 購入日
-  startedAt   DateTime?  @db.Date // 読書開始日
-  finishedAt  DateTime?  @db.Date // 読了日
+  purchasedAt DateTime? // 購入日
+  startedAt   DateTime? // 読書開始日
+  finishedAt  DateTime? // 読了日
   note        String     @default("") // メモ
   status      BookStatus @default(CONSIDERING_PURCHASE) // 現在の状況
   createdAt   DateTime   @default(now()) // データ作成日


### PR DESCRIPTION
# Issue #3

## 修正内容

DBスキーマをDate型からDateTime型に修正しただけで解決した

## 解決理由

`app/utils/date/index.ts`のdateの中身を確認するとわかるが、サーバ側ではUTC、クライアント（ブラウザ）側のコンソールではJSTになっており、環境のタイムゾーン設定による自動変換が行われていることがわかる
```tsx
/**
 * 日付フォーマット用のヘルパー関数
 * @param {Date} date | null
 * @return {string} フォーマットされた日付
 */
export function formatDate(date: Date | null) {
  if (!date) return "-"
  console.log(date)  // debug
  return format(date, "yyyy年MM月dd日", { locale: ja })
}
```

## 補足

なお、date-fnsのlocale設定は、日付のフォーマット時に使用される言語や地域固有の設定を指定するためのものであり、無関係。あとで曜日などを利用することを考えて付与してある
```ts
// locale: ja なし
format(date, "yyyy年MM月dd日 EEEE")   // "2024年01月20日 Saturday"

// locale: ja あり
format(date, "yyyy年MM月dd日 EEEE", { locale: ja })   //  "2024年01月20日 土曜日"
```
