### PR TITLE
[fix]add search parameters to pagination URLs

### DIFF
--- a/src/app/components/pagination/index.tsx
+++ b/src/app/components/pagination/index.tsx
@@ -1,3 +1,6 @@
+"use client"
+
+import { useSearchParams } from "next/navigation"
 import {
   Pagination,
   PaginationContent,
@@ -21,13 +24,15 @@ export function BookPagination({
   totalPages,
   baseUrl = "",
 }: BookPaginationProps) {
+  const searchParams = useSearchParams()
+
   return (
     <div className="py-4">
       <Pagination>
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
-              href={getPageUrl(baseUrl, currentPage - 1)}
+              href={getPageUrl(baseUrl, currentPage - 1, searchParams)}
               aria-disabled={currentPage <= 1}
               className={
                 currentPage <= 1 ? "pointer-events-none opacity-50" : ""
@@ -38,7 +43,7 @@ export function BookPagination({
           {/* 最初のページ */}
           <PaginationItem>
             <PaginationLink
-              href={getPageUrl(baseUrl, 1)}
+              href={getPageUrl(baseUrl, 1, searchParams)}
               isActive={currentPage === 1}
             >
               1
@@ -50,7 +55,10 @@ export function BookPagination({
 
           {currentPage > 2 && currentPage < totalPages && (
             <PaginationItem>
-              <PaginationLink href={getPageUrl(baseUrl, currentPage)} isActive>
+              <PaginationLink
+                href={getPageUrl(baseUrl, currentPage, searchParams)}
+                isActive
+              >
                 {currentPage}
               </PaginationLink>
             </PaginationItem>
@@ -62,7 +70,7 @@ export function BookPagination({
           {totalPages > 1 && (
             <PaginationItem>
               <PaginationLink
-                href={getPageUrl(baseUrl, totalPages)}
+                href={getPageUrl(baseUrl, totalPages, searchParams)}
                 isActive={currentPage === totalPages}
               >
                 {totalPages}
@@ -72,7 +80,7 @@ export function BookPagination({
 
           <PaginationItem>
             <PaginationNext
-              href={getPageUrl(baseUrl, currentPage + 1)}
+              href={getPageUrl(baseUrl, currentPage + 1, searchParams)}
               aria-disabled={currentPage >= totalPages}
               className={
                 currentPage >= totalPages

--- a/src/app/utils/url/index.test.ts
+++ b/src/app/utils/url/index.test.ts
@@ -4,22 +4,33 @@ import { getPageUrl } from "./"
 
 describe("getPageUrl", () => {
   it("ベースURLにページ番号を追加したURLを返す", () => {
-    expect(getPageUrl("/books", 1)).toBe("/books?p=1")
-    expect(getPageUrl("/books", 5)).toBe("/books?p=5")
-    expect(getPageUrl("/users", 10)).toBe("/users?p=10")
+    const params = new URLSearchParams()
+    expect(getPageUrl("/books", 1, params)).toBe("/books?p=1")
+    expect(getPageUrl("/books", 5, params)).toBe("/books?p=5")
+    expect(getPageUrl("/users", 10, params)).toBe("/users?p=10")
   })
 
   it("空のベースURLの場合でも正しく動作する", () => {
-    expect(getPageUrl("", 1)).toBe("?p=1")
-    expect(getPageUrl("", 3)).toBe("?p=3")
+    const params = new URLSearchParams()
+    expect(getPageUrl("", 1, params)).toBe("?p=1")
+    expect(getPageUrl("", 3, params)).toBe("?p=3")
   })
 
-  it("既存のクエリパラメータがないURLでも正しく動作する", () => {
-    expect(getPageUrl("/search", 2)).toBe("/search?p=2")
+  it("既存のクエリパラメータを維持したまま新しいページ番号を追加する", () => {
+    const params = new URLSearchParams("status=reading&sort=title")
+    expect(getPageUrl("/books", 2, params)).toBe(
+      "/books?status=reading&sort=title&p=2",
+    )
+  })
+
+  it("既存のページパラメータを上書きする", () => {
+    const params = new URLSearchParams("status=reading&p=1")
+    expect(getPageUrl("/books", 3, params)).toBe("/books?status=reading&p=3")
   })
 
   it("数値型のページ番号を文字列として正しく連結する", () => {
-    expect(getPageUrl("/books", 0)).toBe("/books?p=0")
-    expect(getPageUrl("/books", -1)).toBe("/books?p=-1")
+    const params = new URLSearchParams()
+    expect(getPageUrl("/books", 0, params)).toBe("/books?p=0")
+    expect(getPageUrl("/books", -1, params)).toBe("/books?p=-1")
   })
 })

--- a/src/app/utils/url/index.ts
+++ b/src/app/utils/url/index.ts
@@ -2,8 +2,15 @@
  * クエリにページ番号を追加したURLを取得
  * @param {string} baseUrl ベースとなるURL
  * @param {number} page ページ番号
- * @return {string} ページ番号を追加したURL
+ * @param {URLSearchParams} searchParams 現在のクエリパラメータ
+ * @return {string} ページ番号とその他のパラメータを含むURL
  */
-export function getPageUrl(baseUrl: string, page: number) {
-  return `${baseUrl}?p=${page}`
+export function getPageUrl(
+  baseUrl: string,
+  page: number,
+  searchParams: URLSearchParams,
+) {
+  const params = new URLSearchParams(searchParams)
+  params.set("p", page.toString())
+  return `${baseUrl}?${params.toString()}`
 }


### PR DESCRIPTION
- ページ移動時、ステータスでフィルタした情報やソート情報が失われてしまっていたのでクエリをgetPageUrl関数に渡すように修正