### PR TITLE
[Refactor] divide components and remove unnecessary useCallback etc...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiori",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/actions/books.ts
+++ b/src/app/actions/books.ts
@@ -1,7 +1,5 @@
 "use server"
 
-import { BookStatus, Prisma } from "@prisma/client"
-
 import type {
   BookResult,
   BooksResult,
@@ -9,9 +7,10 @@ import type {
   SortDirection,
   SortOption,
   UpdateBookInput,
-} from "./../types"
-import { prisma } from "./../database/prismaclient"
-import { getDateValue, getNumberValue, getStringValue } from "./../utils/form"
+} from "@/app/types"
+import { prisma } from "@/app/database/prismaclient"
+import { getDateValue, getNumberValue, getStringValue } from "@/app/utils/form"
+import { BookStatus, Prisma } from "@prisma/client"
 
 /**
  * 全書籍情報の取得

--- a/src/app/books/detail/[id]/page.tsx
+++ b/src/app/books/detail/[id]/page.tsx
@@ -1,10 +1,9 @@
 import Link from "next/link"
 import { getBook } from "@/app/actions/books"
+import { BookDetailsTable } from "@/app/components/books/BookDetailsTable"
+import { DeleteButton, EditButton } from "@/app/components/buttons"
+import { UnauthenticatedView } from "@/app/components/UnauthenticatedView"
 import { currentUser } from "@clerk/nextjs/server"
-
-import { BookDetailsTable } from "./../../../components/books/BookDetailsTable"
-import { DeleteButton, EditButton } from "./../../../components/buttons"
-import { UnauthenticatedView } from "./../../../components/UnauthenticatedView"
 
 export default async function DetailBookPage({
   params,

--- a/src/app/books/edit/[id]/page.tsx
+++ b/src/app/books/edit/[id]/page.tsx
@@ -1,8 +1,7 @@
 import { getBook } from "@/app/actions/books"
+import { UpdateBookForm } from "@/app/components/books/UpdateBookForm"
+import { UnauthenticatedView } from "@/app/components/UnauthenticatedView"
 import { currentUser } from "@clerk/nextjs/server"
-
-import { UpdateBookForm } from "./../../../components/books/UpdateBookForm"
-import { UnauthenticatedView } from "./../../../components/UnauthenticatedView"
 
 export default async function editBookPage({
   params,

--- a/src/app/books/new/page.tsx
+++ b/src/app/books/new/page.tsx
@@ -1,7 +1,6 @@
+import { CreateBookForm } from "@/app/components/books/CreateBookForm"
+import { UnauthenticatedView } from "@/app/components/UnauthenticatedView"
 import { currentUser } from "@clerk/nextjs/server"
-
-import { CreateBookForm } from "./../../components/books/CreateBookForm"
-import { UnauthenticatedView } from "./../../components/UnauthenticatedView"
 
 export default async function NewBookPage() {
   const user = await currentUser()

--- a/src/app/components/bars/index.tsx
+++ b/src/app/components/bars/index.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-
-import { calculateProgress } from "./../../utils/book"
+import { calculateProgress } from "@/app/utils/book"
 
 type ProgressBarCellProps = {
   pagesRead: number

--- a/src/app/components/books/BookDetailsTable.tsx
+++ b/src/app/components/books/BookDetailsTable.tsx
@@ -1,10 +1,9 @@
+import type { Book, Status } from "@/app/types"
+import { ProgressBarCell } from "@/app/components/bars"
+import { STATUS_CONFIG } from "@/app/consts"
+import { formatDate } from "@/app/utils/date"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table"
-
-import type { Book, Status } from "./../../types"
-import { STATUS_CONFIG } from "./../../consts"
-import { formatDate } from "./../../utils/date"
-import { ProgressBarCell } from "./../bars"
 
 type BookDetailsTableProps = {
   book: Book

--- a/src/app/components/books/BooksTable.tsx
+++ b/src/app/components/books/BooksTable.tsx
@@ -1,6 +1,9 @@
 "use client"
 
+import type { Book, Status } from "@/app/types"
 import Link from "next/link"
+import { STATUS_CONFIG } from "@/app/consts"
+import { formatDate } from "@/app/utils/date"
 import { Badge } from "@/components/ui/badge"
 import {
   Table,
@@ -10,10 +13,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-
-import type { Book, Status } from "./../../types"
-import { STATUS_CONFIG } from "./../../consts"
-import { formatDate } from "./../../utils/date"
 
 type BooksTableProps = {
   books: Book[]

--- a/src/app/components/books/BooksTable.tsx
+++ b/src/app/components/books/BooksTable.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import Link from "next/link"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+import type { Book, Status } from "./../../types"
+import { STATUS_CONFIG } from "./../../consts"
+import { formatDate } from "./../../utils/date"
+
+type BooksTableProps = {
+  books: Book[]
+}
+
+export function BooksTable({ books }: BooksTableProps) {
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>タイトル</TableHead>
+            <TableHead className="hidden sm:table-cell">著者</TableHead>
+            <TableHead>ステータス</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {books.map((book) => (
+            <TableRow key={book.id}>
+              <TableCell className="w-2/3 font-medium sm:w-2/5">
+                <Link
+                  href={`/books/detail/${book.id}`}
+                  key={book.id}
+                  className="text-indigo-500 hover:underline"
+                >
+                  {book.title}
+                </Link>
+                <div className="text-xs text-slate-500">
+                  更新日 {formatDate(book.updatedAt)}
+                </div>
+                <div className="text-xs text-slate-500">
+                  登録日 {formatDate(book.createdAt)}
+                </div>
+              </TableCell>
+              <TableCell className="hidden sm:table-cell sm:w-2/5">
+                {book.author ?? "-"}
+              </TableCell>
+              <TableCell className="w-1/3 sm:w-1/5">
+                <Badge variant={STATUS_CONFIG[book.status as Status].variant}>
+                  {STATUS_CONFIG[book.status as Status].label}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+          {books.length === 0 && (
+            <TableRow>
+              <TableCell
+                colSpan={3}
+                className="text-center text-muted-foreground"
+              >
+                登録されている本はありません
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/src/app/components/books/UpdateBookForm.tsx
+++ b/src/app/components/books/UpdateBookForm.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import type { Book } from "@/app/types"
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { updateBook } from "@/app/actions/books"
+import { dateToString } from "@/app/utils/date"
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
 import { Input } from "@/components/ui/input"
@@ -23,9 +25,6 @@ import { cn } from "@/lib/utils"
 import { format } from "date-fns"
 import { Calendar as CalendarIcon } from "lucide-react"
 import { toast } from "sonner"
-
-import type { Book } from "./../../types"
-import { dateToString } from "./../../utils/date"
 
 type BookDetailsTableProps = {
   book: Book

--- a/src/app/components/buttons/index.tsx
+++ b/src/app/components/buttons/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import {
   AlertDialog,
@@ -214,29 +214,20 @@ export function StatusFilterButton({ initialStatus }: StatusFilterButtonProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // 現在のURLパラメータを新しいステータスで更新する
-  const createQueryString = useCallback(
-    (status: string | null) => {
-      const params = new URLSearchParams(searchParams.toString())
+  function createQueryString(status: string | null) {
+    const params = new URLSearchParams(searchParams.toString())
 
-      // statusが選択された場合のみ追加、そうでなければ削除
-      if (status) {
-        params.set("status", status)
-      } else {
-        params.delete("status")
-      }
+    if (status) {
+      params.set("status", status)
+    } else {
+      params.delete("status")
+    }
 
-      // ページをリセット
-      params.delete("p")
+    params.delete("p")
+    return params.toString()
+  }
 
-      return params.toString()
-    },
-    [searchParams],
-  )
-
-  // ステータス変更のハンドラ
   function handleStatusChange(value: string) {
-    // "ALL"の場合はステータスフィルタを削除
     const newStatus = value === "ALL" ? null : value
     router.push(`?${createQueryString(newStatus)}`)
   }

--- a/src/app/components/buttons/index.tsx
+++ b/src/app/components/buttons/index.tsx
@@ -33,7 +33,7 @@ import {
 } from "lucide-react"
 import { toast } from "sonner"
 
-import type { SortDirection, SortOption } from "./../../types"
+import type { SortDirection, SortItem, SortOption } from "./../../types"
 import { deleteBook } from "./../../actions/books"
 import { STATUS_CONFIG } from "./../../consts"
 
@@ -131,11 +131,6 @@ export function DeleteButton({ bookId }: DeleteBookButtonProps) {
 type SortButtonProps = {
   initialSortBy: SortOption
   initialSortDirection: SortDirection
-}
-
-type SortItem = {
-  label: string
-  value: SortOption
 }
 
 export function SortButton({

--- a/src/app/components/buttons/index.tsx
+++ b/src/app/components/buttons/index.tsx
@@ -1,7 +1,10 @@
 "use client"
 
+import type { SortDirection, SortItem, SortOption } from "@/app/types"
 import { useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { deleteBook } from "@/app/actions/books"
+import { STATUS_CONFIG } from "@/app/consts"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,10 +35,6 @@ import {
   Trash2,
 } from "lucide-react"
 import { toast } from "sonner"
-
-import type { SortDirection, SortItem, SortOption } from "./../../types"
-import { deleteBook } from "./../../actions/books"
-import { STATUS_CONFIG } from "./../../consts"
 
 export function NewButton() {
   return (

--- a/src/app/components/pagination/index.tsx
+++ b/src/app/components/pagination/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useSearchParams } from "next/navigation"
+import { getPageUrl } from "@/app/utils/url"
 import {
   Pagination,
   PaginationContent,
@@ -10,8 +11,6 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination"
-
-import { getPageUrl } from "./../../utils/url"
 
 type BookPaginationProps = {
   currentPage: number

--- a/src/app/consts/index.ts
+++ b/src/app/consts/index.ts
@@ -1,4 +1,4 @@
-import type { Status, StatusConfig } from "./../types"
+import type { Status, StatusConfig } from "@/app/types"
 
 export const STATUS_CONFIG: Record<Status, StatusConfig> = {
   CONSIDERING_PURCHASE: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next"
+import { Header } from "@/app/components/Header"
 import { Toaster } from "@/components/ui/sonner"
 import { ClerkProvider } from "@clerk/nextjs"
-
-import { Header } from "./components/Header"
 
 import "@/styles/globals.css"
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,14 @@
 import Link from "next/link"
 import { getBooks } from "@/app/actions/books"
-import { Badge } from "@/components/ui/badge"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { currentUser } from "@clerk/nextjs/server"
 import { toast } from "sonner"
 
-import type { SortDirection, SortOption, Status } from "./types"
+import type { SortDirection, SortOption } from "./types"
+import { BooksTable } from "./components/books/BooksTable"
 import { NewButton, SortButton, StatusFilterButton } from "./components/buttons"
 import { BookPagination } from "./components/pagination"
 import { SearchForm } from "./components/SearchForm"
 import { UnauthenticatedView } from "./components/UnauthenticatedView"
-import { STATUS_CONFIG } from "./consts"
-import { formatDate } from "./utils/date"
 import { isValidSortDirection, isValidSortOption } from "./utils/validator"
 
 type Props = {
@@ -90,56 +80,7 @@ export default async function Home({ searchParams }: Props) {
         </div>
       </div>
 
-      <div className="rounded-lg border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>タイトル</TableHead>
-              <TableHead className="hidden sm:table-cell">著者</TableHead>
-              <TableHead>ステータス</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {books.map((book) => (
-              <TableRow key={book.id}>
-                <TableCell className="w-2/3 font-medium sm:w-2/5">
-                  <Link
-                    href={`/books/detail/${book.id}`}
-                    key={book.id}
-                    className="text-indigo-500 hover:underline"
-                  >
-                    {book.title}
-                  </Link>
-                  <div className="text-xs text-slate-500">
-                    更新日 {formatDate(book.updatedAt)}
-                  </div>
-                  <div className="text-xs text-slate-500">
-                    登録日 {formatDate(book.createdAt)}
-                  </div>
-                </TableCell>
-                <TableCell className="hidden sm:table-cell sm:w-2/5">
-                  {book.author ?? "-"}
-                </TableCell>
-                <TableCell className="w-1/3 sm:w-1/5">
-                  <Badge variant={STATUS_CONFIG[book.status as Status].variant}>
-                    {STATUS_CONFIG[book.status as Status].label}
-                  </Badge>
-                </TableCell>
-              </TableRow>
-            ))}
-            {books.length === 0 && (
-              <TableRow>
-                <TableCell
-                  colSpan={3}
-                  className="text-center text-muted-foreground"
-                >
-                  登録されている本はありません
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <BooksTable books={books} />
 
       <BookPagination currentPage={page} totalPages={totalPages} />
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,18 @@
+import type { SortDirection, SortOption } from "@/app/types"
 import Link from "next/link"
 import { getBooks } from "@/app/actions/books"
+import { BooksTable } from "@/app/components/books/BooksTable"
+import {
+  NewButton,
+  SortButton,
+  StatusFilterButton,
+} from "@/app/components/buttons"
+import { BookPagination } from "@/app/components/pagination"
+import { SearchForm } from "@/app/components/SearchForm"
+import { UnauthenticatedView } from "@/app/components/UnauthenticatedView"
+import { isValidSortDirection, isValidSortOption } from "@/app/utils/validator"
 import { currentUser } from "@clerk/nextjs/server"
 import { toast } from "sonner"
-
-import type { SortDirection, SortOption } from "./types"
-import { BooksTable } from "./components/books/BooksTable"
-import { NewButton, SortButton, StatusFilterButton } from "./components/buttons"
-import { BookPagination } from "./components/pagination"
-import { SearchForm } from "./components/SearchForm"
-import { UnauthenticatedView } from "./components/UnauthenticatedView"
-import { isValidSortDirection, isValidSortOption } from "./utils/validator"
 
 type Props = {
   searchParams: Promise<{

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -71,3 +71,9 @@ export type UpdateBookInput = {
 // ソート用
 export type SortOption = "updatedAt" | "createdAt"
 export type SortDirection = "desc" | "asc"
+
+// ソート項目
+export type SortItem = {
+  label: string
+  value: SortOption
+}

--- a/src/app/utils/validator/index.ts
+++ b/src/app/utils/validator/index.ts
@@ -1,4 +1,4 @@
-import type { SortDirection, SortOption } from "./../../types"
+import type { SortDirection, SortOption } from "@/app/types"
 
 /**
  * 有効なソートオプションか判定


### PR DESCRIPTION
- SortItem型を`types`ディレクトリに移動
- 不要なuseCallbackを除去
- indexページの書籍表示領域を`BooksTable`コンポーネントとして切り出し
- 相対パスで読み込んでいたインポート文を、すべてエイリアスを利用した絶対パスに修正
