### PR TITLE
[Fix]UpdateBookFormのinput要素の修正

### DIFF
--- a/src/app/components/books/UpdateBookForm.tsx
+++ b/src/app/components/books/UpdateBookForm.tsx
@@ -94,11 +94,12 @@ export function UpdateBookForm({ book }: BookDetailsTableProps) {
             読了ページ数
           </label>
           <Input
-            type="number"
+            type="text"
             id="pagesRead"
             name="pagesRead"
             defaultValue={book.pagesRead}
-            min="0"
+            pattern="[0-9]*"
+            inputMode="numeric"
             className="mt-1"
           />
         </div>
@@ -107,11 +108,12 @@ export function UpdateBookForm({ book }: BookDetailsTableProps) {
             総ページ数
           </label>
           <Input
-            type="number"
+            type="text"
             id="totalPages"
             name="totalPages"
             defaultValue={book.totalPages}
-            min="0"
+            pattern="[0-9]*"
+            inputMode="numeric"
             className="mt-1"
           />
         </div>


### PR DESCRIPTION
## 修正箇所

- `app/components/books/UpdateBookForm.tsx`の読了ページ数と総ページ数の`input`要素

## 修正理由

入力したページ数と保存したページ数が一致しないケースが多々あったため  
`202`と入力すると`201`で保存されていたりした

## 補足

ローカル上では正常に動作したが、本番環境に起因する問題かもしれないのでマージする前に確認の必要あり